### PR TITLE
Ensure global startup RCs see the right ZDOTDIR

### DIFF
--- a/zshi
+++ b/zshi
@@ -20,7 +20,16 @@ fi
     local rc
     for rc in .zshenv .zprofile .zshrc .zlogin; do
       >$tmp/$rc <<<'{
+  if (( ${+_zshi_global_rcs} )); then
+    "builtin" "set" "-o" "global_rcs"
+    "builtin" "unset" "_zshi_global_rcs"
+  fi
   ZDOTDIR="$_zshi_zdotdir"
+
+  # Not .zshenv because /etc/zshenv has already been read
+  if [[ -o global_rcs && "'$rc'" != ".zshenv" && -f "/etc/'${rc:1}'" && -r "/etc/'${rc:1}'" ]]; then
+    "builtin" "source" "--" "/etc/'${rc:1}'"
+  fi
   if [[ -f "$ZDOTDIR/'$rc'" && -r "$ZDOTDIR/'$rc'" ]]; then
     "builtin" "source" "--" "$ZDOTDIR/'$rc'"
   fi
@@ -29,10 +38,17 @@ fi
         -o "login" && "'$rc'" == ".zlogin" ||
         -o "no_login" && "'$rc'" == ".zshrc" ||
         -o "no_login" && -o "no_interactive" && "'$rc'" == ".zshenv" ]]; then
+    if (( ${+_zshi_global_rcs} )); then
+      set -o global_rcs
+    fi
     "builtin" "unset" "_zshi_rcs" "_zshi_zdotdir"
     "builtin" "command" "rm" "-rf" "--" '${(q)tmp}'
     "builtin" "eval" '${(q)init}'
   else
+    if [[ -o global_rcs ]]; then
+      _zshi_global_rcs=
+    fi
+    set -o no_global_rcs
     _zshi_zdotdir=${ZDOTDIR:-~}
     ZDOTDIR='${(q)tmp}'
   fi


### PR DESCRIPTION
We do this by disabling zsh's builtin behavior to read these startup files and instead doing them ourselves. This allow us to exert control over what ZDOTDIR is set to (we cannot just set ZDOTDIR to the right thing before global startup scripts are executed because this would cause zsh to not execute the custom startup scripts we wrote out to the temporary directory).

In order to maintain compatibility with existing zsh behavior, we stash the state of the GLOBAL_RCS option at the end of our custom startup scripts but before disabling the option. We then restore its state at the beginning of the next startup script (so immediately after zsh *would* have executed the relevant global startup script).

Note that I didn't test this exhaustively (I basically just tested that the behavior described in #3 was fixed).

Fixes #3